### PR TITLE
fix(config): Proxy backend requests under `/api`

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,2 @@
-VITE_BASE_API_URL=http://122.11.173.11:10868
-# VITE_BASE_API_URL=http://127.0.0.1:3335
 VITE_CHAINMARKX_BASE_URL=https://backend.chainmarkx.cognidex.ai
 VITE_CHAINMARKX_USER_ID=admin

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
-const BASE_API_URL = import.meta.env.VITE_BASE_API_URL;
-export const API_URL = `${BASE_API_URL}/v1`;
+export const API_URL = '/api/v1'; // via proxy
 
 export const CHAINMARKX_BASE_URL =
 import.meta.env.VITE_CHAINMARKX_BASE_URL ?? "http://localhost:5000";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,16 +8,17 @@ export default defineConfig({
     host: true,
     allowedHosts: true,
     proxy: {
-      "/v1": {
-        target: "http://122.11.173.11:10868",
+      "/api": {
+        target: "http://127.0.0.1:3335",
         changeOrigin: true,
         secure: false,
+        rewrite: path => path.replace(/^\/api/, '')
       },
-      "/auth": {
-        target: "http://122.11.173.11:10888",
-        changeOrigin: true,
-        secure: false,
-      },
+      // "/auth": {
+      //   target: "http://122.11.173.11:10888",
+      //   changeOrigin: true,
+      //   secure: false,
+      // },
       "/chainmarkx": {
         target: "https://backend.chainmarkx.cognidex.ai",
         changeOrigin: true,


### PR DESCRIPTION
Enables a reverse proxy (e.g., Nginx) to correctly route traffic on a single server: `/` for the frontend and `/api` for the backend.